### PR TITLE
Replace strip-indent with vendored function

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,9 +4,27 @@
 var React = require('react');
 var Parser = require('commonmark').Parser;
 var Renderer = require('commonmark-react-renderer');
-var stripIndent = require('strip-indent');
 
 var PLACEHOLDER = 'super-secret-react-markings-placeholder-if-you-are-seeing-this-then-there-is-a-bug-in-react-markings';
+
+// Source: https://github.com/sindresorhus/strip-indent
+function stripIndent(str) {
+  var match = str.match(/^[ \t]*(?=\S)/gm);
+  if (!match) {
+    return str;
+  }
+
+  var indent = Math.min.apply(Math, match.map(function (x) {
+    return x.length;
+  }));
+
+  if (indent === 0) {
+    return str;
+  }
+
+  const re = new RegExp(`^[ \\t]{${indent}}`, 'gm');
+  return str.replace(re, '');
+}
 
 function validate(node) {
   var isValid = true;

--- a/package.json
+++ b/package.json
@@ -20,8 +20,7 @@
   },
   "dependencies": {
     "commonmark": "^0.27.0",
-    "commonmark-react-renderer": "^4.3.3",
-    "strip-indent": "^2.0.0"
+    "commonmark-react-renderer": "^4.3.3"
   },
   "peerDependencies": {
     "react": "^15.6.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -807,13 +807,9 @@ http-signature@~1.1.0:
     jsprim "^1.2.2"
     sshpk "^1.7.0"
 
-iconv-lite@0.4.13:
+iconv-lite@0.4.13, iconv-lite@~0.4.13:
   version "0.4.13"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.13.tgz#1f88aba4ab0b1508e8312acc39345f36e992e2f2"
-
-iconv-lite@~0.4.13:
-  version "0.4.18"
-  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.18.tgz#23d8656b16aae6742ac29732ea8f0336a4789cf2"
 
 in-publish@^2.0.0:
   version "2.0.0"
@@ -1421,17 +1417,13 @@ minimatch@^3.0.2, minimatch@^3.0.3, minimatch@^3.0.4:
   dependencies:
     brace-expansion "^1.1.7"
 
-minimist@0.0.8:
+minimist@0.0.8, minimist@~0.0.1:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
 
 minimist@^1.1.1, "minimist@~ 1.2.0":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
-
-minimist@~0.0.1:
-  version "0.0.10"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.10.tgz#de3f98543dbf96082be48ad1a0c7cda836301dcf"
 
 mkdirp@^0.5.1:
   version "0.5.1"
@@ -1932,10 +1924,6 @@ strip-bom@^2.0.0:
   resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-2.0.0.tgz#6219a85616520491f35788bdbf1447a99c7e6b0e"
   dependencies:
     is-utf8 "^0.2.0"
-
-strip-indent@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/strip-indent/-/strip-indent-2.0.0.tgz#5ef8db295d01e6ed6cbf7aab96998d7822527b68"
 
 supports-color@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
The strip-indent package doesn't use any kind of transpilation,
but it does use arrow functions. In most environments dependencies
are not transpiled, so using this dependency will lead to issues.
While they're not hard to solve, it is probably a good idea to
just replace the module here, as there doesn't seem to be
any interest upstream to transpile the package:

https://github.com/sindresorhus/strip-indent/issues/1

I have not added a separate file since there's no bundling or
transpilation process in place here either. I hope that's
fine :smile: