### PR TITLE
allow to pass custom renderers via `withRenderers` higher order function

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 ```js
 import * as React from 'react';
-import md from 'react-markings';
+import { md } from 'react-markings';
 
 function Example() {
   return (
@@ -27,6 +27,28 @@ export default function ReadMe() {
     - Allows you to write markdown using [commonmark.js](https://github.com/commonmark/commonmark.js)
     - Renders markdown as React elements using [commonmark-react-renderer](https://github.com/rexxars/commonmark-react-renderer)
     - Embed React components inside your markdown (in any paragraph position) like this:
+
+    ${<Example/>}
+  `;
+}
+```
+- Allows you to pass your own `commonmark-react-renderer` renderers [type-renderer-options](https://github.com/rexxars/commonmark-react-renderer#type-renderer-options) via `withRenderers` higher order function like this:
+```js
+import * as React from 'react';
+import { withRenderers } from 'react-markings';
+
+function Example() {
+  return <div>Example</div>;
+}
+
+const md = withRenderers({
+  // customize heading with class
+  heading: props => React.createElement('h' + props.level, { className: 'my-class'}, props.children),
+});
+
+export default function CustomHeading() {
+  return md`
+    # react-markings
 
     ${<Example/>}
   `;

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 ```js
 import * as React from 'react';
-import { md } from 'react-markings';
+import md from 'react-markings';
 
 function Example() {
   return (
@@ -35,19 +35,19 @@ export default function ReadMe() {
 - Allows you to pass your own `commonmark-react-renderer` renderers [type-renderer-options](https://github.com/rexxars/commonmark-react-renderer#type-renderer-options) via `withRenderers` higher order function like this:
 ```js
 import * as React from 'react';
-import { withRenderers } from 'react-markings';
+import md from 'react-markings';
 
 function Example() {
   return <div>Example</div>;
 }
 
-const md = withRenderers({
+const mdWithCustomRenderers = md.withRenderers({
   // customize heading with class
   heading: props => React.createElement('h' + props.level, { className: 'my-class'}, props.children),
 });
 
 export default function CustomHeading() {
-  return md`
+  return mdWithCustomRenderers`
     # react-markings
 
     ${<Example/>}

--- a/README.md
+++ b/README.md
@@ -32,25 +32,22 @@ export default function ReadMe() {
   `;
 }
 ```
-- Allows you to pass your own `commonmark-react-renderer` renderers [type-renderer-options](https://github.com/rexxars/commonmark-react-renderer#type-renderer-options) via `withRenderers` higher order function like this:
+
+If you want to customize rendering further, you can use `withRenderers` to pass your
+own [renderers](https://github.com/rexxars/commonmark-react-renderer#type-renderer-options).
+
 ```js
 import * as React from 'react';
-import md from 'react-markings';
+import { withRenderers } from 'react-markings';
 
-function Example() {
-  return <div>Example</div>;
-}
-
-const mdWithCustomRenderers = md.withRenderers({
+let md = withRenderers({
   // customize heading with class
-  heading: props => React.createElement('h' + props.level, { className: 'my-class'}, props.children),
+  heading: props => React.createElement('h' + props.level, { className: 'fancy-heading' }, props.children),
 });
 
 export default function CustomHeading() {
   return mdWithCustomRenderers`
-    # react-markings
-
-    ${<Example/>}
+    # Fancy Heading
   `;
 }
 ```

--- a/index.js
+++ b/index.js
@@ -98,7 +98,6 @@ function withRenderers(renderers /*: ?{[key: string]: (props: Object) => ReactNo
   }
 }
 
-module.exports = {
-  md: withRenderers(),
-  withRenderers: withRenderers,
-}
+let md = withRenderers();
+md.withRenderers = withRenderers;
+module.exports = md;

--- a/index.js
+++ b/index.js
@@ -68,32 +68,37 @@ declare type ReactNode =
   | Iterable<ReactNode>;
 */
 
-function markings(strings /*: Array<string> */ /*::, ...values: Array<ReactNode> */) {
-  var values = Array.prototype.slice.call(arguments, 1);
-  var input = stripIndent(strings.join(PLACEHOLDER));
-  var parser = new Parser();
-  var ast = parser.parse(input);
+function withRenderers(renderers, /*: Array<ReactNode> */) {
+  return function markings(strings /*: Array<string> */ /*::, ...values: Array<ReactNode> */) {
+    var values = Array.prototype.slice.call(arguments, 1);
+    var input = stripIndent(strings.join(PLACEHOLDER));
+    var parser = new Parser();
+    var ast = parser.parse(input);
 
-  if (!validate(ast)) {
-    throw new Error('react-markings cannot interpolate React elements non-block positions');
+    if (!validate(ast)) {
+      throw new Error('react-markings cannot interpolate React elements non-block positions');
+    }
+
+    var index = 0;
+    var renderer = new Renderer({
+      renderers: Object.assign({}, renderers, {
+        Paragraph: function(props) {
+          if (props.children.length === 1 && props.children[0] === PLACEHOLDER) {
+            var value = values[index];
+            index = index + 1 < values.length ? index + 1 : 0;
+            return value;
+          } else {
+            return React.createElement('p', {}, props.children);
+          }
+        },
+      })
+    });
+
+    return React.createElement('div', {}, renderer.render(ast));
   }
-
-  var index = 0;
-  var renderer = new Renderer({
-    renderers: {
-      Paragraph: function(props) {
-        if (props.children.length === 1 && props.children[0] === PLACEHOLDER) {
-          var value = values[index];
-          index = index + 1 < values.length ? index + 1 : 0;
-          return value;
-        } else {
-          return React.createElement('p', {}, props.children);
-        }
-      },
-    },
-  });
-
-  return React.createElement('div', {}, renderer.render(ast));
 }
 
-module.exports = markings;
+module.exports = {
+  md: withRenderers(),
+  withRenderers: withRenderers,
+}

--- a/index.js
+++ b/index.js
@@ -68,7 +68,7 @@ declare type ReactNode =
   | Iterable<ReactNode>;
 */
 
-function withRenderers(renderers, /*: Array<ReactNode> */) {
+function withRenderers(renderers /*: ?{[key: string]: (props: Object) => ReactNode} */) {
   return function markings(strings /*: Array<string> */ /*::, ...values: Array<ReactNode> */) {
     var values = Array.prototype.slice.call(arguments, 1);
     var input = stripIndent(strings.join(PLACEHOLDER));

--- a/test.js
+++ b/test.js
@@ -1,7 +1,7 @@
 // @flow
 'use strict';
 
-const md = require('./');
+const { md, withRenderers } = require('./');
 const React = require('react');
 const ReactDOMServer = require('react-dom/server');
 const renderToStaticMarkup = ReactDOMServer.renderToStaticMarkup;
@@ -57,4 +57,15 @@ test('non-blocks', () => {
       \`${element}\`
     `);
   }).toThrow();
+});
+
+test('withRenderers', () => {
+  const mdWithCustomRenderers = withRenderers({
+    heading: props => React.createElement('h' + props.level, { className: 'my-class'}, props.children),
+  });
+
+  expect(renderToStaticMarkup(mdWithCustomRenderers`
+    # Heading
+    ${element}
+  `)).toBe('<div><h1 class="my-class">Heading</h1><div>MyComponent</div></div>');
 });

--- a/test.js
+++ b/test.js
@@ -1,7 +1,7 @@
 // @flow
 'use strict';
 
-const { md, withRenderers } = require('./');
+const md = require('./');
 const React = require('react');
 const ReactDOMServer = require('react-dom/server');
 const renderToStaticMarkup = ReactDOMServer.renderToStaticMarkup;
@@ -60,7 +60,7 @@ test('non-blocks', () => {
 });
 
 test('withRenderers', () => {
-  const mdWithCustomRenderers = withRenderers({
+  const mdWithCustomRenderers = md.withRenderers({
     heading: props => React.createElement('h' + props.level, { className: 'my-class'}, props.children),
   });
 


### PR DESCRIPTION
~This is breaking change because default export is no longer `markings` function but object with `markings` named as `md` and `withRenderers` higher order function to allow to pass custom rendereres to `markings` function.~

Let me now please, if anything should be done differently or decline PR if you don't want this feature. 

Have a nice day!